### PR TITLE
Add relevant images to proposal results for pulsars

### DIFF
--- a/G_P_R.html
+++ b/G_P_R.html
@@ -50,12 +50,14 @@
 						<div class="inner">
 							<h1>Pulsars from the ground in radio wavelengths</h1>
 							
-                            <p><b>Well done, your research proposal was accepted!</b>
+                            <p><b>Well done, your research proposal was accepted!</b></p>
                             
-                            <p>The first pulsar was actually discovered using radio observations from the ground, so its certainly one way to view these objects. Taking observations from the ground is much cheaper, and allows us to build big arrays of telescopes, so that we can improve the quality of our data. We cant wait to see what you will discover!
+                            <p>The first pulsar was actually discovered using radio observations from the ground, so its certainly one way to view these objects. Taking observations from the ground is much cheaper, and allows us to build big arrays of telescopes, so that we can improve the quality of our data. We cant wait to see what you will discover!</p>
                             
-                            <p> You may have been inspired by recent advancements in a technique called pulsar timing, which uses radio observatories on the ground. Because pulsars rotate with stable periods, the pulses we see occur at very regular times. That means astronomers know when we expect signals from certain pulsars to arrive at our detectors.   Researchers have been using these techniques to study a phenomena known as gravitational waves. You can imagine these as ripples in space-time. If a gravitational wave passes through, the space between us and the pulsar will expand and contract. This means the pulses will either arrive earlier or later than they were expected. An example project is the European Pulsar Timing Array (EPTA), which uses 5 radio telescopes scattered across Europe.
+                            <p> You may have been inspired by recent advancements in a technique called pulsar timing, which uses radio observatories on the ground. Because pulsars rotate with stable periods, the pulses we see occur at very regular times. That means astronomers know when we expect signals from certain pulsars to arrive at our detectors.   Researchers have been using these techniques to study a phenomena known as gravitational waves. You can imagine these as ripples in space-time. If a gravitational wave passes through, the space between us and the pulsar will expand and contract. This means the pulses will either arrive earlier or later than they were expected. An example project is the European Pulsar Timing Array (EPTA), which uses 5 radio telescopes scattered across Europe.</p>
                     
+			      <span class="image right"><img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Lovell_Telescope_29.jpg"></span>
+                              <div class="caption left"><i>Right: The Lovell Telescope, at Jodrell Bank in Cheshire, is one of the radio telescopes that comprises the European Pulsar Timing Array (EPTA). Image credit: Mike Peel; Jodrell Bank Centre for Astrophysics, University of Manchester</i></div>
                             
                             
                             

--- a/S_P_X.html
+++ b/S_P_X.html
@@ -52,11 +52,16 @@
 							
                             <p><b>Well done, your research proposal was accepted!</b>
                             
-                            <p>Like the name suggests X-ray pulsars display periodic pulses in X-ray frequencies. Choosing to study these from space was the correct option, as X-rays can't penetrate Earth's atmosphere. We cant wait to see what you will discover!
-                            
-                            <p>You may have been inspired by recent work with a pulsar called SAX J1808.4–3658. The pulsar is a part of a binary system, where two stars orbit a common center. Researchers discovered that this pulsar was sucking mass off its partner, which is a brown dwarf. At first, the material it pulls off orbits around the pulsar in a disk. However, once that disk gets to a certain size, the material starts to be captured by the pulsar. This causes a huge release of energy, causing an outburst of X-rays. The most recent outburst occured in 2019. The event happened a little later than researchers expected, which they believe could be due to a large amount of Helium.
-                            
-                            
+                            <p>Like the name suggests X-ray pulsars display periodic pulses in X-ray frequencies. Choosing to study these from space was the correct option, as X-rays can't penetrate Earth's atmosphere. We can't wait to see what you will discover!</p>
+
+                           <span class="image left"><img src="https://upload.wikimedia.org/wikipedia/commons/a/af/Crab_Nebula_pulsar_x-ray.jpg" width"200" alt="" /></span>
+                           <div class="caption right"><i>Left: X-ray image of the Crab Pulsar taken by the Chandra X-ray Observatory. Image credit: Smithsonian Institution</i></div>
+
+                           <p>You may have been inspired by recent work with a pulsar called SAX J1808.4–3658. The pulsar is a part of a binary system, where two stars orbit a common center. Researchers discovered that this pulsar was sucking mass off its partner, which is a brown dwarf. At first, the material it pulls off orbits around the pulsar in a disk. However, once that disk gets to a certain size, the material starts to be captured by the pulsar. This causes a huge release of energy, causing an outburst of X-rays. <a href="https://www.nasa.gov/feature/goddard/2019/nasas-nicer-catches-record-setting-x-ray-burst">The most recent outburst occured in 2019</a>. The event happened a little later than researchers expected, which they believe could be due to a large amount of Helium.</p>
+
+                           <span class="image right"><img src="https://upload.wikimedia.org/wikipedia/commons/9/9c/Nicer-extraction-loop_0.gif" width"200" alt="" /></span>
+                           <div class="caption left"><i>Right: The Neutron Star Interior Composition Explorer (NICER), an X-ray telescope, being delivered to the International Space Station in 2017. Image credit: NASA</i></div>
+
                             <p><a href="G_S_P_X.html">Back</a>
 						</div>
 					</div>


### PR DESCRIPTION
Like PR #2, this adds a few images to the various pages at the end of the click-through process for pulsars, again by linking to publicly-licensed files online.